### PR TITLE
libreoffice: version bump + icon add + build dep in pspec.xml

### DIFF
--- a/main/office/libreoffice/libreoffice/actions.py
+++ b/main/office/libreoffice/libreoffice/actions.py
@@ -145,6 +145,15 @@ def check():
 
 def install():
     autotools.rawInstall("DESTDIR=%s distro-pack-install -o build -o check" % get.installDIR())
+    
+    pisitools.insinto("/usr/share/pixmaps/", "android/experimental/GSoC-2012-eclipse-workspace/LibreOfficeUI/res/drawable-hdpi/base.png", "libreoffice-base.png")
+    pisitools.insinto("/usr/share/pixmaps/", "android/experimental/GSoC-2012-eclipse-workspace/LibreOfficeUI/res/drawable-hdpi/calc.png", "libreoffice-calc.png")
+    pisitools.insinto("/usr/share/pixmaps/", "android/experimental/GSoC-2012-eclipse-workspace/LibreOfficeUI/res/drawable-hdpi/draw.png", "libreoffice-draw.png")
+    pisitools.insinto("/usr/share/pixmaps/", "android/experimental/GSoC-2012-eclipse-workspace/LibreOfficeUI/res/drawable-hdpi/impress.png", "libreoffice-impress.png")
+    pisitools.insinto("/usr/share/pixmaps/", "android/experimental/GSoC-2012-eclipse-workspace/LibreOfficeUI/res/drawable-hdpi/main.png", "libreoffice-main.png")
+    pisitools.insinto("/usr/share/pixmaps/", "android/experimental/GSoC-2012-eclipse-workspace/LibreOfficeUI/res/drawable-hdpi/math.png", "libreoffice-math.png")
+    pisitools.insinto("/usr/share/pixmaps/", "android/experimental/GSoC-2012-eclipse-workspace/LibreOfficeUI/res/drawable-hdpi/startcenter.png", "libreoffice-startcenter.png")
+    pisitools.insinto("/usr/share/pixmaps/", "android/experimental/GSoC-2012-eclipse-workspace/LibreOfficeUI/res/drawable-hdpi/writer.png", "libreoffice-writer.png")
 
     if not shelltools.isDirectory(langpackpath): shelltools.makedirs(langpackpath)
     else: shelltools.unlinkDir(langpackpath)

--- a/main/office/libreoffice/libreoffice/pspec.xml
+++ b/main/office/libreoffice/libreoffice/pspec.xml
@@ -9,7 +9,7 @@
             <Email>admins@pisilinux.org</Email>
         </Packager>
         <License>LGPLv3</License>
-        <Icon>ooo-gulls</Icon>
+        <Icon>libreoffice-startcenter</Icon>
         <IsA>app:gui</IsA>
         <Summary>LibreOffice office suite</Summary>
         <Description>LibreOffice is an open source, multi-platform office productivity suite. It includes key desktop applications such as a word processor, a spreadsheet application, a presentation creator-viewer, a formula editor and a drawing program, with a user interface and feature set similar to other office suites. Sophisticated and flexible, LibreOffice also works transparently with a variety of file formats, including those of Microsoft Office.</Description>
@@ -74,7 +74,6 @@
             <Dependency>qt-devel</Dependency>
             <Dependency>avahi-devel</Dependency>
             <Dependency>mesa-devel</Dependency>
-            <Dependency>librevenge-devel</Dependency>
             <Dependency>mesa-glu-devel</Dependency>
             <Dependency>lcms2-devel</Dependency>
             <Dependency>poppler-devel</Dependency>
@@ -101,21 +100,19 @@
 
             <Dependency>mdds-devel</Dependency>
             <Dependency versionFrom="0.1.0">libcdr-devel</Dependency>
-            <Dependency versionFrom="0.10.0">libwpd-devel</Dependency>
             <Dependency versionFrom="0.3.0">libwpg-devel</Dependency>
             <Dependency versionFrom="0.3.0">libwps-devel</Dependency>
+            <Dependency versionFrom="0.10.0">libwpd-devel</Dependency>
             <Dependency versionFrom="0.1.1">libmspub-devel</Dependency>
+            <Dependency versionFrom="0.1.0">libvisio-devel</Dependency>
+            <Dependency versionFrom="0.1.1">libodfgen-devel</Dependency>
             <Dependency versionFrom="0.1.1">libetonyek-devel</Dependency>
-            <Dependency>libcmis-devel</Dependency>
-            <Dependency>libodfgen-devel</Dependency>
             <Dependency>libexttextcat-devel</Dependency>
             <Dependency>hyphen-devel</Dependency>
             <Dependency>mythes-devel</Dependency>
             <Dependency>lpsolve-devel</Dependency>
-            <Dependency versionFrom="0.1.0">libvisio-devel</Dependency>
             <Dependency>vigra-devel</Dependency>
             <Dependency>graphite2-devel</Dependency>
-            <Dependency versionFrom="0.1.1">libodfgen-devel</Dependency>
             <Dependency>hunspell-devel</Dependency>
 
             <Dependency>libSM-devel</Dependency>
@@ -158,11 +155,13 @@
 
     <Package>
         <Name>libreoffice-common</Name>
+        <Icon>libreoffice-startcenter</Icon>
         <RuntimeDependencies>
             <Dependency>nss</Dependency>
             <Dependency>cups</Dependency>
             <Dependency>gtk2</Dependency>
             <Dependency>mesa</Dependency>
+            <Dependency>glew</Dependency>
             <Dependency>neon</Dependency>
             <Dependency>cairo</Dependency>
             <Dependency>lcms2</Dependency>
@@ -174,6 +173,7 @@
             <Dependency>libwpd</Dependency>
             <Dependency>libwpg</Dependency>
             <Dependency>mythes</Dependency>
+            <Dependency>libwps</Dependency>
             <Dependency>clucene</Dependency>
             <Dependency>libXext</Dependency>
             <Dependency>libcmis</Dependency>
@@ -226,21 +226,23 @@
         </Conflicts>
         <Files>
             <Path fileType="config">/etc</Path>
-            <Path fileType="executable">/usr/bin/libreoffice</Path>
-            <Path fileType="executable">/usr/bin/loffice</Path>
-            <Path fileType="executable">/usr/bin/lofromtemplate</Path>
-            <Path fileType="executable">/usr/bin/soffice</Path>
-            <Path fileType="executable">/usr/bin/unopkg</Path>
-            <Path fileType="library">/usr/lib/libreoffice/program/*.so</Path>
-            <Path fileType="data">/usr/lib/libreoffice/</Path>
             <Path fileType="man">/usr/share/man</Path>
             <Path fileType="data">/usr/share/mime</Path>
             <Path fileType="data">/usr/share/icons</Path>
             <Path fileType="data">/usr/share/mimelnk</Path>
             <Path fileType="data">/usr/share/appdata</Path>
             <Path fileType="data">/usr/share/mime-info</Path>
+            <Path fileType="executable">/usr/bin/unopkg</Path>
+            <Path fileType="data">/usr/lib/libreoffice/</Path>
+            <Path fileType="executable">/usr/bin/soffice</Path>
+            <Path fileType="executable">/usr/bin/loffice</Path>
             <Path fileType="doc">/usr/share/doc/libreoffice</Path>
+            <Path fileType="executable">/usr/bin/libreoffice</Path>
+            <Path fileType="executable">/usr/bin/lofromtemplate</Path>
             <Path fileType="data">/usr/share/application-registry</Path>
+            <Path fileType="library">/usr/lib/libreoffice/program/*.so</Path>
+            <Path fileType="data">/usr/share/pixmaps/libreoffice-main.png</Path>
+            <Path fileType="data">/usr/share/pixmaps/libreoffice-startcenter.png</Path>
             <Path fileType="data">/usr/share/applications/libreoffice-xsltfilter.desktop</Path>
             <Path fileType="data">/usr/share/applications/libreoffice-startcenter.desktop</Path>
         </Files>
@@ -251,6 +253,7 @@
 
     <Package>
         <Name>libreoffice-base</Name>
+        <Icon>libreoffice-base</Icon>
         <Summary>Database front-end for LibreOffice</Summary>
         <RuntimeDependencies>
             <Dependency>libreoffice-common</Dependency>
@@ -259,6 +262,7 @@
             <Path fileType="executable">/usr/bin/lobase</Path>
             <Path fileType="man">/usr/share/man/man1/lobase.1.gz</Path>
             <Path fileType="data">/usr/lib/libreoffice/program/sbase</Path>
+            <Path fileType="data">/usr/share/pixmaps/libreoffice-base.png</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libabplo.so</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libdbplo.so</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libdbulo.so</Path>
@@ -287,6 +291,7 @@
 
     <Package>
         <Name>libreoffice-calc</Name>
+        <Icon>libreoffice-calc</Icon>
         <Summary>Spreadsheet application for LibreOffice.</Summary>
         <RuntimeDependencies>
             <Dependency>lpsolve</Dependency>
@@ -296,6 +301,7 @@
             <Path fileType="executable">/usr/bin/localc</Path>
             <Path fileType="data">/usr/share/man/man1/localc.1.gz</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/scalc</Path>
+            <Path fileType="data">/usr/share/pixmaps/libreoffice-calc.png</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libscdlo.so</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libcalclo.so</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libdatelo.so</Path>
@@ -310,6 +316,7 @@
 
     <Package>
         <Name>libreoffice-draw</Name>
+        <Icon>libreoffice-draw</Icon>
         <Summary>Drawing Application for LibreOffice.</Summary>
         <RuntimeDependencies>
             <Dependency>poppler</Dependency>
@@ -318,6 +325,7 @@
         <Files>
             <Path fileType="executable">/usr/bin/lodraw</Path>
             <Path fileType="data">/usr/share/man/man1/lodraw.1.gz</Path>
+            <Path fileType="data">/usr/share/pixmaps/libreoffice-draw.png</Path>
             <Path fileType="data">/usr/lib/libreoffice/program/xpdfimport</Path>
             <Path fileType="data">/usr/lib/libreoffice/share/registry/draw.xcd</Path>
             <Path fileType="data">/usr/share/applications/libreoffice-draw.desktop</Path>
@@ -329,6 +337,7 @@
 
     <Package>
         <Name>libreoffice-gnome</Name>
+        <Icon>libreoffice-startcenter</Icon>
         <Summary>Plug-in for LibreOffice that enables integration into the Gnome and other gtk desktop environment.</Summary>
         <RuntimeDependencies>
             <Dependency>atk</Dependency>
@@ -356,15 +365,15 @@
 
     <Package>
         <Name>libreoffice-impress</Name>
+        <Icon>libreoffice-impress</Icon>
         <Summary>Presentation Application for LibreOffice.</Summary>
         <RuntimeDependencies>
-            <Dependency>mesa</Dependency>
-            <Dependency>mesa-glu</Dependency>
             <Dependency>libreoffice-common</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="executable">/usr/bin/loimpress</Path>
             <Path fileType="data">/usr/share/man/man1/loimpress.1.gz</Path>
+            <Path fileType="data">/usr/share/pixmaps/libreoffice-impress.png</Path>
             <Path fileType="data">/usr/lib/libreoffice/share/registry/impress.xcd</Path>
             <Path fileType="data">/usr/lib/libreoffice/share/registry/ogltrans.xcd</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libanimcorelo.so</Path>
@@ -380,6 +389,7 @@
 
     <Package>
         <Name>libreoffice-kde</Name>
+        <Icon>libreoffice-startcenter</Icon>
         <Summary>Plug-in for LibreOffice that enables integration into the KDE4 desktop environment.</Summary>
         <RuntimeDependencies>
             <Dependency>qt</Dependency>
@@ -396,6 +406,7 @@
 
     <Package>
         <Name>libreoffice-math</Name>
+        <Icon>libreoffice-math</Icon>
         <Summary>Equation Editor Application for LibreOffice.</Summary>
         <RuntimeDependencies>
             <Dependency>libreoffice-common</Dependency>
@@ -404,6 +415,7 @@
             <Path fileType="executable">/usr/bin/lomath</Path>
             <Path fileType="data">/usr/share/man/man1/lomath.1.gz</Path>
             <Path fileType="data">/usr/lib/libreoffice/program/smath</Path>
+            <Path fileType="data">/usr/share/pixmaps/libreoffice-math.png</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libsmlo.so</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libsmdlo.so</Path>
             <Path fileType="data">/usr/lib/libreoffice/share/registry/math.xcd</Path>
@@ -413,6 +425,7 @@
 
     <Package>
         <Name>libreoffice-postgresql</Name>
+        <Icon>libreoffice-startcenter</Icon>
         <Summary>A PostgreSQL connector for the database front-end for LibreOffice</Summary>
         <RuntimeDependencies>
             <Dependency>postgresql-lib</Dependency>
@@ -429,6 +442,7 @@
 
     <Package>
         <Name>libreoffice-rhino</Name>
+        <Icon>libreoffice-startcenter</Icon>
         <Summary>JavaScript support for LibreOffice</Summary>
         <RuntimeDependencies>
             <Dependency>libreoffice-common</Dependency>
@@ -443,6 +457,7 @@
 
     <Package>
         <Name>libreoffice-sdk</Name>
+        <Icon>libreoffice-startcenter</Icon>
         <Summary>Software Development Kit for LibreOffice.</Summary>
         <RuntimeDependencies>
             <Dependency>libreoffice-common</Dependency>
@@ -457,6 +472,7 @@
 
     <Package>
         <Name>libreoffice-sdk-doc</Name>
+        <Icon>libreoffice-startcenter</Icon>
         <Summary>Software Development Kit documentation for LibreOffice</Summary>
         <RuntimeDependencies>
             <Dependency>libreoffice-sdk</Dependency>
@@ -469,12 +485,16 @@
 
     <Package>
         <Name>libreoffice-writer</Name>
+        <Icon>libreoffice-writer</Icon>
         <Summary>Word Processor Application for LibreOffice.</Summary>
         <RuntimeDependencies>
+            <Dependency>icu4c</Dependency>
             <Dependency>libwpd</Dependency>
             <Dependency>libwpg</Dependency>
             <Dependency>libwps</Dependency>
+            <Dependency>libmwaw</Dependency>
             <Dependency>libodfgen</Dependency>
+            <Dependency>librevenge</Dependency>
             <Dependency>libreoffice-common</Dependency>
         </RuntimeDependencies>
         <Files>
@@ -485,6 +505,7 @@
             <Path fileType="library">/usr/share/man/man1/lowriter.1.gz</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/swriter</Path>
             <Path fileType="library">/usr/lib/libreoffice/share/registry/</Path>
+            <Path fileType="data">/usr/share/pixmaps/libreoffice-writer.png</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libhwplo.so</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/libswuilo.so</Path>
             <Path fileType="library">/usr/lib/libreoffice/program/liblwpftlo.so</Path>


### PR DESCRIPTION
1. 4.3.5.1 sürümüne güncellendi.
2. Oluşan paketlere icon etiketi eklendi.
3. Bazı depleri pspec.xml içerisine alındı.
