### PR TITLE
efivar: version bump + /usr/lib64 edit + /usr/lib64 linklemesi giderildi...

### DIFF
--- a/extra/system/boot/efivar/actions.py
+++ b/extra/system/boot/efivar/actions.py
@@ -12,8 +12,7 @@ from pisi.actionsapi import get
 def build():
     shelltools.export("CFLAGS", "-Os")
     pisitools.dosed("Make.defaults","-O0","-Os")
-#    pisitools.dosed("src/test/Makefile","(TOPDIR)/src/","(libdir)")
-    autotools.make("V=1 -j1")
+    autotools.make("libdir=/usr/lib bindir=/usr/bin")
 
 def install():
-     autotools.rawInstall("DESTDIR=%s" % get.installDIR())
+     autotools.rawInstall("DESTDIR=%s libdir=/usr/lib/" % get.installDIR())

--- a/extra/system/boot/efivar/pspec.xml
+++ b/extra/system/boot/efivar/pspec.xml
@@ -12,25 +12,33 @@
         <IsA>app:console</IsA>
         <Summary>Tools and library to manipulate EFI variables</Summary>
         <Description>Tools and library to manipulate EFI variables.</Description>
-        <Archive sha1sum="217d26a5db586adccc930c9468f54df07aca57fc" type="targz">http://source.pisilinux.org/1.0/efivar.tar.gz</Archive>
+        <Archive sha1sum="db9553acd4ac3fc39ed2bb3078da17348646d8ea" type="tarbz2">https://github.com/rhinstaller/efivar/releases/download/0.15/efivar-0.15.tar.bz2</Archive>
     </Source>
 
     <Package>
         <Name>efivar</Name>
         <Files>
-            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="library">/usr/lib</Path>
             <Path fileType="man">/usr/share/man</Path>
-            <Path fileType="library">/usr/lib64/*</Path>
+            <Path fileType="executable">/usr/bin</Path>
         </Files>
     </Package>
     <Package>
         <Name>efivar-devel</Name>
         <Files>
             <Path fileType="header">/usr/include</Path>
+            <Path fileType="data">/usr/lib/pkgconfig</Path>
         </Files>
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>2015-02-21</Date>
+            <Version>0.15</Version>
+            <Comment>Version Bump</Comment>
+            <Name>Osman Erkan</Name>
+            <Email>osman.erkan@pisilinux.org</Email>
+        </Update>
         <Update release="1">
             <Date>2014-09-27</Date>
             <Version>0.10.8</Version>


### PR DESCRIPTION
/usr/lib64 dizinine eklenen so dosyaları derleme dizinindeki dosyalara linkleniyordu.
/usr/lib64 dizini yerine /usr/lib kullanması sağlandı.
güncellendi.