### PR TITLE
webkit-gtk, gtk-doc, wepb, harfbuzz, gobject-intros., which version bump and liferea fixed

### DIFF
--- a/extra/desktop/xfce/addon/liferea/pspec.xml
+++ b/extra/desktop/xfce/addon/liferea/pspec.xml
@@ -35,9 +35,6 @@
             <Dependency>gobject-introspection-devel</Dependency>
             <Dependency>libpeas-devel</Dependency>
         </BuildDependencies>
-        <Patches>
-            <Patch>webkit_error.patch</Patch>
-        </Patches>
     </Source>
 
     <Package>

--- a/extra/network/misc/webkit-gtk3/pspec.xml
+++ b/extra/network/misc/webkit-gtk3/pspec.xml
@@ -14,32 +14,52 @@
         <IsA>library</IsA>
         <Summary>An opensource web browser engine for GTK+ 3.x applications</Summary>
         <Description>The GTK+ 3.x port of WebKit is intended to provide a browser component primarily for users of the portable GTK+ 3.x UI toolkit on platforms like Linux.</Description>
-        <Archive sha1sum="da83c4e7b36917e307155ebe3ae93621e4802d83" type="tarxz">http://www.webkitgtk.org/releases/webkitgtk-2.4.1.tar.xz</Archive>
+        <Archive sha1sum="44c6bbe52108297126830525619c1df047886a6f" type="tarxz">http://www.webkitgtk.org/releases/webkitgtk-2.4.8.tar.xz</Archive>
         <BuildDependencies>
-            <Dependency>gtk-doc</Dependency>
-            <Dependency>atk-devel</Dependency>
-            <Dependency>gtk2-devel</Dependency>
-            <Dependency>gtk3-devel</Dependency>
-            <Dependency>webp-devel</Dependency>
+			<Dependency versionFrom="10.4.3">mesa-devel</Dependency>
+            <Dependency versionFrom="1.21">gtk-doc</Dependency>
+            <Dependency versionFrom="2.24.23">gtk2-devel</Dependency>
+            <Dependency versionFrom="3.6">gtk3-devel</Dependency>
+            <Dependency versionFrom="2.36.0">glib2-devel</Dependency>
+            <Dependency versionFrom="0.4.3">webp-devel</Dependency>
             <Dependency>cairo-devel</Dependency>
-            <Dependency>icu4c-devel</Dependency>
+            <Dependency versionFrom="54.1">icu4c-devel</Dependency>
             <Dependency>libXt-devel</Dependency>
-            <Dependency>pango-devel</Dependency>
-            <Dependency>enchant-devel</Dependency>
-            <Dependency>geoclue-devel</Dependency>
-            <Dependency>libsoup-devel</Dependency>
+            <Dependency versionFrom="1.6.0">enchant-devel</Dependency>
+            <Dependency versionFrom="0.12.0">geoclue-devel</Dependency>
+            <Dependency versionFrom="2.49.1">libsoup-devel</Dependency>
+            <Dependency versionFrom="2.5">fontconfig-devel</Dependency>
             <Dependency>libxslt-devel</Dependency>
-            <Dependency>harfbuzz-devel</Dependency>
-            <Dependency>libsecret-devel</Dependency>
-            <Dependency>gdk-pixbuf-devel</Dependency>
+            <Dependency versionFrom="0.9.40">harfbuzz-devel</Dependency>
+            <Dependency versionFrom="0.18">libsecret-devel</Dependency>
             <Dependency>libjpeg-turbo-devel</Dependency>
+            <Dependency>phonon-backend-gstreamer</Dependency>
             <Dependency>gstreamer-next-devel</Dependency>
-            <Dependency>libgnome-keyring-devel</Dependency>
-            <Dependency>gobject-introspection-devel</Dependency>
             <Dependency>gst-plugins-base-next-devel</Dependency>
+            <Dependency versionFrom="1.40.0">gobject-introspection-devel</Dependency>
+            <Dependency>at-spi2-core-devel</Dependency>
+            <Dependency>bison</Dependency>
+            <Dependency>chrpath</Dependency>
+            <Dependency>flex</Dependency>
+            <Dependency>freetype-devel</Dependency>
+            <Dependency>geoclue2-devel</Dependency>
+            <Dependency versionFrom="2.36.0">glib2-devel</Dependency>
+            <Dependency>libsecret-devel</Dependency>
+            <Dependency>libpcre-devel</Dependency>
+            <Dependency versionFrom="3.8.8.3">sqlite-devel</Dependency>
+            <Dependency>ruby</Dependency>
+            <Dependency versionFrom="2.21">which</Dependency>
+            <Dependency>libxml2-devel</Dependency>
+            <Dependency>expat-devel</Dependency>
+            <Dependency>libX11-devel</Dependency>
+            <Dependency>libXdmcp-devel</Dependency>
+            <Dependency>libffi-devel</Dependency>
+            <Dependency>libgudev1-devel</Dependency>
+            <Dependency>libgcrypt-devel</Dependency>
+            <Dependency>gperf</Dependency>
+            <Dependency>libtool</Dependency>
+            <Dependency versionFrom="0.12">icon-theme-hicolor</Dependency>
         </BuildDependencies>
-        <Patches>
-        </Patches>
     </Source>
 
     <Package>
@@ -50,16 +70,23 @@
             <Dependency>gtk3</Dependency>
             <Dependency>mesa</Dependency>
             <Dependency>webp</Dependency>
+            <Dependency>zlib</Dependency>
             <Dependency>cairo</Dependency>
             <Dependency>icu4c</Dependency>
+            <Dependency>glib2</Dependency>
             <Dependency>libXt</Dependency>
             <Dependency>pango</Dependency>
+            <Dependency>libX11</Dependency>
+            <Dependency>libgcc</Dependency>
+            <Dependency>libpng</Dependency>
+            <Dependency>sqlite</Dependency>
             <Dependency>enchant</Dependency>
-            <Dependency>geoclue</Dependency>
             <Dependency>libsoup</Dependency>
+            <Dependency>libxml2</Dependency>
             <Dependency>libxslt</Dependency>
+            <Dependency>freetype</Dependency>
             <Dependency>harfbuzz</Dependency>
-            <Dependency>libXfixes</Dependency>
+            <Dependency>libgudev1</Dependency>
             <Dependency>libsecret</Dependency>
             <Dependency>fontconfig</Dependency>
             <Dependency>gdk-pixbuf</Dependency>
@@ -84,7 +111,9 @@
         <IsA>data:doc</IsA>
         <Summary>Development files for GTK+ port of WebKit</Summary>
         <RuntimeDependencies>
+            <Dependency>libgcc</Dependency>
             <Dependency>gtk3-devel</Dependency>
+            <Dependency>glib2-devel</Dependency>
             <Dependency release="current">webkit-gtk3</Dependency>
             <Dependency>libsoup-devel</Dependency>
         </RuntimeDependencies>
@@ -99,6 +128,13 @@
     </Package>
 
     <History>
+        <Update release="7">
+            <Date>2014-05-24</Date>
+            <Version>2.4.8</Version>
+            <Comment>Version bump  and it must be version bump together webkit-gtk2</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="6">
             <Date>2014-05-24</Date>
             <Version>2.4.1</Version>

--- a/main/desktop/font/harfbuzz/pspec.xml
+++ b/main/desktop/font/harfbuzz/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>library</IsA>
         <Summary>OpenType text shaping engine.</Summary>
         <Description>The Harfbuzz package contains an OpenType text shaping engine.</Description>
-        <Archive sha1sum="00c24a228206a5646166630e02b542d7d3fb4544" type="tarbz2">http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.38.tar.bz2</Archive>
+        <Archive sha1sum="b9f546e9625926e32fe4b6da045689b456e77c22" type="tarbz2">http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.40.tar.bz2</Archive>
         <BuildDependencies>
             <Dependency>cairo-devel</Dependency>
             <Dependency>glib2-devel</Dependency>
@@ -25,7 +25,10 @@
         <Name>harfbuzz</Name>
         <RuntimeDependencies>
             <Dependency>cairo</Dependency>
+            <Dependency>glib2</Dependency>
             <Dependency>icu4c</Dependency>
+            <Dependency>libgcc</Dependency>
+            <Dependency>freetype</Dependency>
             <Dependency>graphite2</Dependency>
         </RuntimeDependencies>
         <Files>
@@ -40,8 +43,8 @@
     <Package>
         <Name>harfbuzz-devel</Name>
         <RuntimeDependencies>
+            <Dependency>glib2-devel</Dependency>
             <Dependency>icu4c-devel</Dependency>
-            <Dependency release="current">harfbuzz</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="header">/usr/include/harfbuzz</Path>
@@ -64,9 +67,9 @@
         <RuntimeDependencies>
             <Dependency>cairo-32bit</Dependency>
             <Dependency>glib2-32bit</Dependency>
+            <Dependency>glibc-32bit</Dependency>
             <Dependency>icu4c-32bit</Dependency>
             <Dependency>freetype-32bit</Dependency>
-            <Dependency release="current">harfbuzz</Dependency>
         </RuntimeDependencies>
         <Files>
             <Path fileType="library">/usr/lib32</Path>
@@ -74,6 +77,13 @@
     </Package>
 
     <History>
+        <Update release="15">
+            <Date>2015-04-06</Date>
+            <Version>0.9.40</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="14">
             <Date>2015-01-24</Date>
             <Version>0.9.38</Version>

--- a/main/desktop/toolkit/gtk/gtk-doc/pspec.xml
+++ b/main/desktop/toolkit/gtk/gtk-doc/pspec.xml
@@ -13,7 +13,7 @@
         <IsA>app:console</IsA>
         <Summary>GTK+ API documentation generator</Summary>
         <Description>Gtk-Doc is typically used to document the public API of GTK+ and GNOME libraries, but it can also be used to document application code.</Description>
-        <Archive sha1sum="dac60c7044bfd2e8a2462c99aaf64b98c777dc51" type="tarxz">mirrors://gnome/gtk-doc/1.20/gtk-doc-1.20.tar.xz</Archive>
+        <Archive sha1sum="49b4fc9d4cf618c53f39f35f4cf2fc27b7b3dae4" type="tarxz">mirrors://gnome/gtk-doc/1.21/gtk-doc-1.21.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>rarian</Dependency>
             <Dependency>itstool</Dependency>
@@ -41,6 +41,13 @@
     </Package>
 
     <History>
+        <Update release="5">
+            <Date>2015-04-06</Date>
+            <Version>1.21</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="4">
             <Date>2014-05-18</Date>
             <Version>1.20</Version>

--- a/main/multimedia/graphics/webp/pspec.xml
+++ b/main/multimedia/graphics/webp/pspec.xml
@@ -12,7 +12,7 @@
         <IsA>application</IsA>
         <Summary>webp image format and format conversion png,jpeg,tiff</Summary>
         <Description>webp image format and format conversion png,jpeg,tiff</Description>
-        <Archive sha1sum="326c4b6787a01e5e32a9b30bae76442d18d2d1b6" type="targz">https://webp.googlecode.com/files/libwebp-0.4.0.tar.gz</Archive>
+        <Archive sha1sum="1c307a61c4d0018620b4ba9a58e8f48a8d6640ef" type="targz">http://downloads.webmproject.org/releases/webp/libwebp-0.4.3.tar.gz</Archive>
         <BuildDependencies>
             <Dependency>mesa-devel</Dependency>
             <Dependency>tiff-devel</Dependency>
@@ -29,6 +29,7 @@
             <Dependency>tiff</Dependency>
             <Dependency>mesa</Dependency>
             <Dependency>giflib</Dependency>
+            <Dependency>libpng</Dependency>
             <Dependency>freeglut</Dependency>
             <Dependency>libjpeg-turbo</Dependency>
         </RuntimeDependencies>
@@ -52,6 +53,13 @@
     </Package>
 
     <History>
+        <Update release="6">
+            <Date>2015-04-06</Date>
+            <Version>0.4.3</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="5">
             <Date>2014-05-21</Date>
             <Version>0.4.0</Version>

--- a/main/network/misc/webkit-gtk2/pspec.xml
+++ b/main/network/misc/webkit-gtk2/pspec.xml
@@ -14,31 +14,36 @@
         <IsA>library</IsA>
         <Summary>An opensource web browser engine for GTK+ applications</Summary>
         <Description>The GTK+ port of WebKit is intended to provide a browser component primarily for users of the portable GTK+ UI toolkit on platforms like Linux.</Description>
-        <Archive sha1sum="10d4cd1c1f7454adc576c6b97fa3d262b6665764" type="tarxz">http://www.webkitgtk.org/releases/webkitgtk-2.4.7.tar.xz</Archive>
+        <Archive sha1sum="44c6bbe52108297126830525619c1df047886a6f" type="tarxz">http://www.webkitgtk.org/releases/webkitgtk-2.4.8.tar.xz</Archive>
         <BuildDependencies>
-            <Dependency>mesa</Dependency>
-            <Dependency>gtk-doc</Dependency>
+            <Dependency versionFrom="10.4.3">mesa-devel</Dependency>
+            <Dependency versionFrom="1.21">gtk-doc</Dependency>
             <Dependency>atk-devel</Dependency>
-            <Dependency>gtk2-devel</Dependency>
-            <Dependency>ruby-devel</Dependency>
-            <Dependency>webp-devel</Dependency>
+            <Dependency>zlib-devel</Dependency>
+            <Dependency versionFrom="2.36.0">glib2-devel</Dependency>
+            <Dependency versionFrom="2.24.23">gtk2-devel</Dependency>
+            <Dependency versionFrom="2.2.1">ruby-devel</Dependency>
+            <Dependency versionFrom="0.4.3">webp-devel</Dependency>
             <Dependency>cairo-devel</Dependency>
-            <Dependency>icu4c-devel</Dependency>
+            <Dependency versionFrom="54.1">icu4c-devel</Dependency>
             <Dependency>libXt-devel</Dependency>
             <Dependency>pango-devel</Dependency>
-            <Dependency>enchant-devel</Dependency>
-            <Dependency>geoclue-devel</Dependency>
-            <Dependency>libsoup-devel</Dependency>
+            <Dependency versionFrom="1.6.0">enchant-devel</Dependency>
+            <Dependency versionFrom="3.8.8.3">sqlite-devel</Dependency>
+            <Dependency versionFrom="0.12.0">geoclue-devel</Dependency>
+            <Dependency versionFrom="2.49.1">libsoup-devel</Dependency>
+            <Dependency versionFrom="2.5">fontconfig-devel</Dependency>
             <Dependency>libxslt-devel</Dependency>
-            <Dependency>harfbuzz-devel</Dependency>
-            <Dependency>libsecret-devel</Dependency>
+            <Dependency versionFrom="0.9.40">harfbuzz-devel</Dependency>
+            <Dependency versionFrom="0.18">libsecret-devel</Dependency>
             <Dependency>gdk-pixbuf-devel</Dependency>
             <Dependency>libXcomposite-devel</Dependency>
             <Dependency>libjpeg-turbo-devel</Dependency>
             <Dependency>gstreamer-next-devel</Dependency>
-            <Dependency>libgnome-keyring-devel</Dependency>
-            <Dependency>gobject-introspection-devel</Dependency>
+            <Dependency versionFrom="1.40.0">gobject-introspection-devel</Dependency>
             <Dependency>gst-plugins-base-next-devel</Dependency>
+            <Dependency versionFrom="2.21">which</Dependency>
+            <Dependency versionFrom="0.12">icon-theme-hicolor</Dependency>
         </BuildDependencies>
         <Patches>
         </Patches>
@@ -48,19 +53,25 @@
         <Name>webkit-gtk2</Name>
         <RuntimeDependencies>
             <Dependency>atk</Dependency>
+            <Dependency>zlib</Dependency>
+            <Dependency>glib2</Dependency>
             <Dependency>gtk2</Dependency>
             <Dependency>mesa</Dependency>
-            <Dependency>ruby</Dependency>
             <Dependency>webp</Dependency>
             <Dependency>cairo</Dependency>
             <Dependency>icu4c</Dependency>
             <Dependency>libXt</Dependency>
+            <Dependency>libX11</Dependency>
+            <Dependency>libgcc</Dependency>
+            <Dependency>libpng</Dependency>
+            <Dependency>libxml2</Dependency>
             <Dependency>pango</Dependency>
+            <Dependency>sqlite</Dependency>
             <Dependency>enchant</Dependency>
-            <Dependency>geoclue</Dependency>
             <Dependency>libsoup</Dependency>
             <Dependency>libxslt</Dependency>
             <Dependency>harfbuzz</Dependency>
+            <Dependency>freetype</Dependency>
             <Dependency>libsecret</Dependency>
             <Dependency>fontconfig</Dependency>
             <Dependency>gdk-pixbuf</Dependency>
@@ -84,7 +95,9 @@
         <IsA>data:doc</IsA>
         <Summary>Development files for GTK+ port of WebKit</Summary>
         <RuntimeDependencies>
+            <Dependency>libgcc</Dependency>
             <Dependency>gtk2-devel</Dependency>
+            <Dependency>glib2-devel</Dependency>
             <Dependency release="current">webkit-gtk2</Dependency>
             <Dependency>libsoup-devel</Dependency>
         </RuntimeDependencies>
@@ -99,9 +112,16 @@
     </Package>
 
     <History>
+		<Update release="8">
+            <Date>2015-04-07</Date>
+            <Version>2.4.8</Version>
+            <Comment>Version Bump</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="7">
             <Date>2015-01-16</Date>
-            <Version>2.4.7</Version>
+            <Version>2.4.8</Version>
             <Comment>Version Bump + Rebuild.</Comment>
             <Name>Osman Erkan</Name>
             <Email>osman.erkan@pisilinux.org</Email>

--- a/main/system/base/which/pspec.xml
+++ b/main/system/base/which/pspec.xml
@@ -12,9 +12,9 @@
         <IsA>app:console</IsA>
         <Summary>Prints the location of specified executable in your path</Summary>
         <Description>which , Locates a program file in the user's path.</Description>
-        <Archive sha1sum="3bcd6d87aa5231917ba7123319eedcae90cfa0fd" type="targz">mirrors://gnu/which/which-2.20.tar.gz</Archive>
+        <Archive sha1sum="6b6bec3d2b3d4661c164feb81b9b1d22d1359ded" type="targz">mirrors://gnu/which/which-2.21.tar.gz</Archive>
         <Patches>
-            <Patch level="1">which-gentoo.patch</Patch>
+            <!--<Patch level="1">which-gentoo.patch</Patch>-->
         </Patches>
     </Source>
 
@@ -29,6 +29,13 @@
     </Package>
 
     <History>
+        <Update release="4">
+            <Date>2015-04-06</Date>
+            <Version>2.21</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="3">
             <Date>2014-05-11</Date>
             <Version>2.20</Version>

--- a/main/system/devel/gobject-introspection/pspec.xml
+++ b/main/system/devel/gobject-introspection/pspec.xml
@@ -14,7 +14,7 @@
         <IsA>app:console</IsA>
         <Summary>Introspection system for GObject-based libraries</Summary>
         <Description>gobject-introspection can scan C header and source files in order to generate introspection typelib files. It also provides an API to examine typelib files, useful for creating language bindings among other things.</Description>
-        <Archive sha1sum="6eb5476838650f8b3cdd14100081f3416eebf6b7" type="tarxz">mirrors://gnome/gobject-introspection/1.40/gobject-introspection-1.40.0.tar.xz</Archive>
+        <Archive sha1sum="5bae1d170e19d6b3de2d1dd2554d5fc1230ee5fd" type="tarxz">mirrors://gnome/gobject-introspection/1.44/gobject-introspection-1.44.0.tar.xz</Archive>
         <BuildDependencies>
             <Dependency>cairo-devel</Dependency>
             <Dependency>python-devel</Dependency>
@@ -57,6 +57,13 @@
     </Package>
 
     <History>
+        <Update release="11">
+            <Date>2015-04-06</Date>
+            <Version>1.44.0</Version>
+            <Comment>Version bump.</Comment>
+            <Name>Ayhan Yalçınsoy</Name>
+            <Email>ayhanyalcinsoy@pisilinux.org</Email>
+        </Update>
         <Update release="10">
             <Date>2014-05-11</Date>
             <Version>1.40.0</Version>


### PR DESCRIPTION
webkit-gtk  version bump to 2.4.8 
webkit-gtk3 version bump to 2.4.8
gtk-doc version bump to 1.21 
webp version bump to 0.4.3 
harfbuzz version bump to 0.9.40 
gobject-introspection version bump to 1.44.0 
which version bump to 2.21 
liferea fixed*